### PR TITLE
[CodeThreat] Update Newtonsoft.Json from 11.0.1 to 13.0.1

### DIFF
--- a/src/NETWebFormsBlot/packages.config
+++ b/src/NETWebFormsBlot/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net472" />
   <package id="AspNet.ScriptManager.bootstrap" version="3.4.1" targetFramework="net472" />
@@ -14,6 +14,6 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.0" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="Modernizr" version="2.8.3" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
This PR was generated by CodeThreat utilizing authenticated user credentials.

  ## Issue Description

  ### Newtonsoft.Json before version 13.0.1 is affected by a mishandling of exceptional conditions vulnerability. Crafted data that is passed to the JsonConvert.DeserializeObject method may trigger a StackOverflow exception resulting in denial of service. Depending on the usage of the library, an unauthenticated and remote attacker may be able to cause the denial of service condition.

  
  ### Changes included in this PR
  
  - Modifications to the following files to address the vulnerabilities with updated dependencies:
    - src/NETWebFormsBlot/packages.config
  
  ### Security Issues Addressed
  
  #### Through Dependency Upgrades:
  
  | Issue | Upgrade | Severity |
  | --- | --- | --- |
  | Improper Handling of Exceptional Conditions in Newtonsoft.Json | Newtonsoft.Json: 11.0.1 -> 13.0.1 | HIGH |
  
  Review the modifications in this PR to confirm they do not introduce any issues to your project.
  